### PR TITLE
Android: added location service

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     compile project(':ReactAndroid')
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.google.android.gms:play-services-maps:10.0.1'
+    compile 'com.google.android.gms:play-services-location:10.0.1'
     compile 'com.google.firebase:firebase-messaging:10.0.1'
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,8 +40,16 @@
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
         <!-- [START location_service] -->
-        <service android:name=".LocationService.YettaLocationService"
-            android:exported="false" />
+        <!--<service -->
+            <!--android:name=".LocationService.LocationUpdatesIntentService"-->
+            <!--android:exported="false" />-->
+        <receiver
+            android:name=".LocationService.LocationUpdatesBroadcastReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.pingstersapp.LocationService.LocationUpdatesBroadcastReceiver.ACTION_PROCESS_UPDATES" />
+            </intent-filter>
+        </receiver>
         <!-- [END location_service] -->
 
         <!-- [START firebase_service] -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".MainApplication"
@@ -37,6 +38,11 @@
             </intent-filter>
         </activity>
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+
+        <!-- [START location_service] -->
+        <service android:name=".LocationService.YettaLocationService"
+            android:exported="false" />
+        <!-- [END location_service] -->
 
         <!-- [START firebase_service] -->
         <service

--- a/android/app/src/main/java/com/pingstersapp/LocationService/LocationUpdatesBroadcastReceiver.java
+++ b/android/app/src/main/java/com/pingstersapp/LocationService/LocationUpdatesBroadcastReceiver.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingstersapp.LocationService;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.util.Log;
+
+import com.google.android.gms.location.LocationResult;
+
+import java.util.List;
+
+/**
+ * Receiver for handling location updates.
+ *
+ * For apps targeting API level O
+ * {@link android.app.PendingIntent#getBroadcast(Context, int, Intent, int)} should be used when
+ * requesting location updates. Due to limits on background services,
+ * {@link android.app.PendingIntent#getService(Context, int, Intent, int)} should not be used.
+ *
+ *  Note: Apps running on "O" devices (regardless of targetSdkVersion) may receive updates
+ *  less frequently than the interval specified in the
+ *  {@link com.google.android.gms.location.LocationRequest} when the app is no longer in the
+ *  foreground.
+ */
+public class LocationUpdatesBroadcastReceiver extends BroadcastReceiver {
+    private static final String TAG = "LUBroadcastReceiver";
+
+    public static final String ACTION_PROCESS_UPDATES =
+            "com.pingstersapp.LocationService.action" +
+                    ".PROCESS_UPDATES";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent != null) {
+            final String action = intent.getAction();
+            if (ACTION_PROCESS_UPDATES.equals(action)) {
+                LocationResult result = LocationResult.extractResult(intent);
+                if (result != null) {
+                    List<Location> locations = result.getLocations();
+                    Utils.setLocationUpdatesResult(context, locations);
+                    Utils.sendNotification(context, Utils.getLocationResultTitle(context, locations));
+                    Log.i(TAG, "location update in background/terminated");
+                    Log.i(TAG, Utils.getLocationUpdatesResult(context));
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/pingstersapp/LocationService/LocationUpdatesIntentService.java
+++ b/android/app/src/main/java/com/pingstersapp/LocationService/LocationUpdatesIntentService.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pingstersapp.LocationService;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.android.gms.location.LocationResult;
+
+import java.util.List;
+
+/**
+ * Handles incoming location updates and displays a notification with the location data.
+ *
+ * For apps targeting API level 25 ("Nougat") or lower, location updates may be requested
+ * using {@link android.app.PendingIntent#getService(Context, int, Intent, int)} or
+ * {@link android.app.PendingIntent#getBroadcast(Context, int, Intent, int)}. For apps targeting
+ * API level O, only {@code getBroadcast} should be used.
+ *
+ *  Note: Apps running on "O" devices (regardless of targetSdkVersion) may receive updates
+ *  less frequently than the interval specified in the
+ *  {@link com.google.android.gms.location.LocationRequest} when the app is no longer in the
+ *  foreground.
+ */
+public class LocationUpdatesIntentService extends IntentService {
+
+    public static final String ACTION_PROCESS_UPDATES =
+            "com.google.android.gms.location.sample.locationupdatespendingintent.action" +
+                    ".PROCESS_UPDATES";
+    private static final String TAG = LocationUpdatesIntentService.class.getSimpleName();
+
+
+    public LocationUpdatesIntentService() {
+        // Name the worker thread.
+        super(TAG);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        if (intent != null) {
+            final String action = intent.getAction();
+            if (ACTION_PROCESS_UPDATES.equals(action)) {
+                LocationResult result = LocationResult.extractResult(intent);
+                if (result != null) {
+                    List<Location> locations = result.getLocations();
+                    Utils.setLocationUpdatesResult(this, locations);
+                    Utils.sendNotification(this, Utils.getLocationResultTitle(this, locations));
+                    Log.i(TAG, Utils.getLocationUpdatesResult(this));
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/pingstersapp/LocationService/Utils.java
+++ b/android/app/src/main/java/com/pingstersapp/LocationService/Utils.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingstersapp.LocationService;
+
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.location.Location;
+import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.TaskStackBuilder;
+
+import com.pingstersapp.MainActivity;
+import com.pingstersapp.R;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Utility methods used in this sample.
+ */
+public class Utils {
+
+    public final static String KEY_LOCATION_UPDATES_REQUESTED = "location-updates-requested";
+    public final static String KEY_LOCATION_UPDATES_RESULT = "location-update-result";
+
+    public static void setRequestingLocationUpdates(Context context, boolean value) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(KEY_LOCATION_UPDATES_REQUESTED, value)
+                .apply();
+    }
+
+    public static boolean getRequestingLocationUpdates(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(KEY_LOCATION_UPDATES_REQUESTED, false);
+    }
+
+    /**
+     * Posts a notification in the notification bar when a transition is detected.
+     * If the user clicks the notification, control goes to the MainActivity.
+     */
+    static void sendNotification(Context context, String notificationDetails) {
+        // Create an explicit content Intent that starts the main Activity.
+        Intent notificationIntent = new Intent(context, MainActivity.class);
+
+        notificationIntent.putExtra("from_notification", true);
+
+        // Construct a task stack.
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(context);
+
+        // Add the main Activity to the task stack as the parent.
+        stackBuilder.addParentStack(MainActivity.class);
+
+        // Push the content Intent onto the stack.
+        stackBuilder.addNextIntent(notificationIntent);
+
+        // Get a PendingIntent containing the entire back stack.
+        PendingIntent notificationPendingIntent =
+                stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        // Get a notification builder that's compatible with platform versions >= 4
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+
+        // Define the notification settings.
+        builder.setSmallIcon(R.mipmap.ic_launcher)
+                // In a real app, you may want to use a library like Volley
+                // to decode the Bitmap.
+                .setLargeIcon(BitmapFactory.decodeResource(context.getResources(),
+                        R.mipmap.ic_launcher))
+                .setColor(Color.RED)
+                .setContentTitle("Location update")
+                .setContentText(notificationDetails)
+                .setContentIntent(notificationPendingIntent);
+
+        // Dismiss notification once the user touches it.
+        builder.setAutoCancel(true);
+
+        // Get an instance of the Notification manager
+        NotificationManager mNotificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        // Issue the notification
+        mNotificationManager.notify(0, builder.build());
+    }
+
+
+    /**
+     * Returns the title for reporting about a list of {@link Location} objects.
+     *
+     * @param context The {@link Context}.
+     */
+    static String getLocationResultTitle(Context context, List<Location> locations) {
+        String numLocationsReported = java.lang.Integer.toString(locations.size());
+        return numLocationsReported + ": " + DateFormat.getDateTimeInstance().format(new Date());
+    }
+
+    /**
+     * Returns te text for reporting about a list of  {@link Location} objects.
+     *
+     * @param locations List of {@link Location}s.
+     */
+    private static String getLocationResultText(Context context, List<Location> locations) {
+        if (locations.isEmpty()) {
+            return "unknown location";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Location location : locations) {
+            sb.append("(");
+            sb.append(location.getLatitude());
+            sb.append(", ");
+            sb.append(location.getLongitude());
+            sb.append(")");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    static void setLocationUpdatesResult(Context context, List<Location> locations) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putString(KEY_LOCATION_UPDATES_RESULT, getLocationResultTitle(context, locations)
+                        + "\n" + getLocationResultText(context, locations))
+                .apply();
+    }
+
+    public static String getLocationUpdatesResult(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(KEY_LOCATION_UPDATES_RESULT, "");
+    }
+}

--- a/android/app/src/main/java/com/pingstersapp/MainActivity.java
+++ b/android/app/src/main/java/com/pingstersapp/MainActivity.java
@@ -1,22 +1,116 @@
 package com.pingstersapp;
 
+import android.app.PendingIntent;
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.IntentSender;
+import android.content.SharedPreferences;
+import android.location.Location;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.location.LocationListener;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationSettingsResult;
+import com.google.android.gms.location.LocationSettingsStatusCodes;
 
-import javax.annotation.Nullable;
+import java.text.DateFormat;
+import java.util.Date;
 
-import static android.content.ContentValues.TAG;
+import com.pingstersapp.LocationService.*;
+/**
+ * Using location settings.
+ * <p/>
+ * for foreground, LocationListener is recommended to use.
+ * for background, intentService is recommended to use.
+ */
+public class MainActivity extends ReactActivity implements
+        GoogleApiClient.ConnectionCallbacks,
+        GoogleApiClient.OnConnectionFailedListener,
+        LocationListener {
 
-public class MainActivity extends ReactActivity {
+    protected static final String TAG = "MainActivity";
+
+    /**
+     * for foreground
+     * Constant used in the location settings dialog.
+     */
+    protected static final int REQUEST_CHECK_SETTINGS = 0x1;
+
+    /**
+     * for foreground
+     * The desired interval for location updates. Inexact. Updates may be more or less frequent.
+     */
+    public static final long UPDATE_INTERVAL_IN_MILLISECONDS = 10000;
+
+    /**
+     * for foreground
+     * The fastest rate for active location updates. Exact. Updates will never be more frequent
+     * than this value.
+     */
+    public static final long FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS =
+            UPDATE_INTERVAL_IN_MILLISECONDS / 2;
+
+    // Keys for storing activity state in the Bundle.
+    protected final static String KEY_REQUESTING_LOCATION_UPDATES = "requesting-location-updates";
+    protected final static String KEY_LOCATION = "location";
+    protected final static String KEY_LAST_UPDATED_TIME_STRING = "last-updated-time-string";
+
+    /**
+     * Provides the entry point to Google Play services.
+     */
+    protected GoogleApiClient mGoogleApiClient;
+
+    /**
+     * Stores parameters for requests to the FusedLocationProviderApi.
+     */
+    protected LocationRequest mLocationRequest;
+
+    /**
+     * Stores the types of location services the client is interested in using. Used for checking
+     * settings to determine if the device has optimal location settings.
+     */
+    protected LocationSettingsRequest mLocationSettingsRequest;
+
+    /**
+     * Represents a geographical location.
+     */
+    protected Location mCurrentLocation;
+
+    /**
+     * Tracks the status of the location updates request. Value changes when the user presses the
+     * Start Updates and Stop Updates buttons.
+     */
+    protected Boolean mRequestingLocationUpdates;
+
+    /**
+     * Time when the location was updated represented as a String.
+     */
+    protected String mLastUpdateTime;
+
+    /**
+     * Returns the name of the main component registered from JavaScript.
+     * This is used to schedule rendering of the component.
+     */
+    @Override
+    protected String getMainComponentName() {
+        return "pingstersApp";
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,6 +124,7 @@ public class MainActivity extends ReactActivity {
         // is used when no click_action is specified.
         //
         // Handle possible data accompanying notification message.
+
         // [START handle_data_extras]
         WritableMap params = Arguments.createMap();
         if (getIntent().getExtras() != null) {
@@ -41,6 +136,7 @@ public class MainActivity extends ReactActivity {
         }
         // [END handle_data_extras]
 
+        // [START handle push notification after app terminated]
         final Intent message = getIntent();
 
         IntentFilter intentFilter = new IntentFilter("com.pingstersapp.fcm.ReceiveNotificationKilled");
@@ -52,17 +148,28 @@ public class MainActivity extends ReactActivity {
                 sendOrderedBroadcast(i, null);
             }
         }, intentFilter);
+        // [END handle push notification after app terminated]
+
+        // [START handle location service]
+
+        // todo: change the following to follow user settings
+        mRequestingLocationUpdates = true;
+        mLastUpdateTime = "";
+
+        // Update values using data stored in the Bundle.
+        updateValuesFromBundle(savedInstanceState);
+
+        // Kick off the process of building the GoogleApiClient, LocationRequest, and
+        // LocationSettingsRequest objects.
+        buildGoogleApiClient();
+        createLocationRequest();
+        buildLocationSettingsRequest();
+        // [END handle location service]
     }
 
     /**
-     * Returns the name of the main component registered from JavaScript.
-     * This is used to schedule rendering of the component.
+     * this is for push notification when app in background
      */
-    @Override
-    protected String getMainComponentName() {
-        return "pingstersApp";
-    }
-
     @Override
     public void onNewIntent (Intent intent) {
         super.onNewIntent(intent);
@@ -77,5 +184,328 @@ public class MainActivity extends ReactActivity {
         i.putExtra("message", getIntent()); // todo: change getIntent() to appropriate
         sendOrderedBroadcast(i, null);
         setIntent(intent);
+    }
+
+    /**
+     * Updates fields based on data stored in the bundle.
+     *
+     * @param savedInstanceState The activity state saved in the Bundle.
+     */
+    private void updateValuesFromBundle(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            // Update the value of mRequestingLocationUpdates from the Bundle, and make sure that
+            // the Start Updates and Stop Updates buttons are correctly enabled or disabled.
+            if (savedInstanceState.keySet().contains(KEY_REQUESTING_LOCATION_UPDATES)) {
+                mRequestingLocationUpdates = savedInstanceState.getBoolean(
+                        KEY_REQUESTING_LOCATION_UPDATES);
+            }
+
+            // Update the value of mCurrentLocation from the Bundle and update the UI to show the
+            // correct latitude and longitude.
+            if (savedInstanceState.keySet().contains(KEY_LOCATION)) {
+                // Since KEY_LOCATION was found in the Bundle, we can be sure that mCurrentLocation
+                // is not null.
+                mCurrentLocation = savedInstanceState.getParcelable(KEY_LOCATION);
+            }
+
+            // Update the value of mLastUpdateTime from the Bundle and update the UI.
+            if (savedInstanceState.keySet().contains(KEY_LAST_UPDATED_TIME_STRING)) {
+                mLastUpdateTime = savedInstanceState.getString(KEY_LAST_UPDATED_TIME_STRING);
+            }
+            // updateUI();
+        }
+    }
+
+    /**
+     * Builds a GoogleApiClient. Uses the {@code #addApi} method to request the
+     * LocationServices API.
+     */
+    protected synchronized void buildGoogleApiClient() {
+        Log.i(TAG, "Building GoogleApiClient");
+        mGoogleApiClient = new GoogleApiClient.Builder(this)
+                .addConnectionCallbacks(this)
+                .addOnConnectionFailedListener(this)
+                .addApi(LocationServices.API)
+                .build();
+    }
+
+    /**
+     * Sets up the location request. Android has two location request settings:
+     * {@code ACCESS_COARSE_LOCATION} and {@code ACCESS_FINE_LOCATION}. These settings control
+     * the accuracy of the current location. This sample uses ACCESS_FINE_LOCATION, as defined in
+     * the AndroidManifest.xml.
+     * <p/>
+     * When the ACCESS_FINE_LOCATION setting is specified, combined with a fast update
+     * interval (5 seconds), the Fused Location Provider API returns location updates that are
+     * accurate to within a few feet.
+     * <p/>
+     * These settings are appropriate for mapping applications that show real-time location
+     * updates.
+     */
+    protected void createLocationRequest() {
+        mLocationRequest = new LocationRequest();
+
+        // Sets the desired interval for active location updates. This interval is
+        // inexact. You may not receive updates at all if no location sources are available, or
+        // you may receive them slower than requested. You may also receive updates faster than
+        // requested if other applications are requesting location at a faster interval.
+        mLocationRequest.setInterval(UPDATE_INTERVAL_IN_MILLISECONDS);
+
+        // Sets the fastest rate for active location updates. This interval is exact, and your
+        // application will never receive updates faster than this value.
+        mLocationRequest.setFastestInterval(FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS);
+
+        mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+
+        // Sets the maximum time when batched location updates are delivered. Updates may be
+        // delivered sooner than this interval.
+        // mLocationRequest.setMaxWaitTime(MAX_WAIT_TIME);
+    }
+
+    /**
+     * Uses a {@link com.google.android.gms.location.LocationSettingsRequest.Builder} to build
+     * a {@link com.google.android.gms.location.LocationSettingsRequest} that is used for checking
+     * if a device has the needed location settings.
+     */
+    protected void buildLocationSettingsRequest() {
+        LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+        builder.addLocationRequest(mLocationRequest);
+        mLocationSettingsRequest = builder.build();
+    }
+
+    /**
+     * The callback invoked when
+     * {@link com.google.android.gms.location.SettingsApi#checkLocationSettings(GoogleApiClient,
+     * LocationSettingsRequest)} is called. Examines the
+     * {@link com.google.android.gms.location.LocationSettingsResult} object and determines if
+     * location settings are adequate. If they are not, begins the process of presenting a location
+     * settings dialog to the user.
+     */
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            // Check for the integer request code originally supplied to startResolutionForResult().
+            case REQUEST_CHECK_SETTINGS:
+                switch (resultCode) {
+                    case Activity.RESULT_OK:
+                        Log.i(TAG, "User agreed to make required location settings changes.");
+                        // Nothing to do. startLocationupdates() gets called in onResume again.
+                        break;
+                    case Activity.RESULT_CANCELED:
+                        Log.i(TAG, "User chose not to make required location settings changes.");
+                        mRequestingLocationUpdates = false;
+                        // updateUI();
+                        break;
+                }
+                break;
+        }
+    }
+
+    /**
+     * Requests location updates from the FusedLocationApi.
+     */
+    protected void startLocationUpdates() {
+        LocationServices.SettingsApi.checkLocationSettings(
+                mGoogleApiClient,
+                mLocationSettingsRequest
+        ).setResultCallback(new ResultCallback<LocationSettingsResult>() {
+            @Override
+            public void onResult(@NonNull LocationSettingsResult locationSettingsResult) {
+                final Status status = locationSettingsResult.getStatus();
+                switch (status.getStatusCode()) {
+                    case LocationSettingsStatusCodes.SUCCESS:
+                        Log.i(TAG, "All location settings are satisfied.");
+                        LocationServices.FusedLocationApi.requestLocationUpdates(
+                                mGoogleApiClient, mLocationRequest, MainActivity.this);
+                        break;
+                    case LocationSettingsStatusCodes.RESOLUTION_REQUIRED:
+                        Log.i(TAG, "Location settings are not satisfied. Attempting to upgrade " +
+                                "location settings ");
+                        try {
+                            // Show the dialog by calling startResolutionForResult(), and check the
+                            // result in onActivityResult().
+                            status.startResolutionForResult(MainActivity.this, REQUEST_CHECK_SETTINGS);
+                        } catch (IntentSender.SendIntentException e) {
+                            Log.i(TAG, "PendingIntent unable to execute request.");
+                        }
+                        break;
+                    case LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE:
+                        String errorMessage = "Location settings are inadequate, and cannot be " +
+                                "fixed here. Fix in Settings.";
+                        Log.e(TAG, errorMessage);
+                        Toast.makeText(MainActivity.this, errorMessage, Toast.LENGTH_LONG).show();
+                        mRequestingLocationUpdates = false;
+                }
+                // updateUI();
+            }
+        });
+    }
+
+    /**
+     * Removes location updates from the FusedLocationApi.
+     */
+    protected void stopLocationUpdates() {
+        // It is a good practice to remove location requests when the activity is in a paused or
+        // stopped state. Doing so helps battery performance and is especially
+        // recommended in applications that request frequent location updates.
+        LocationServices.FusedLocationApi.removeLocationUpdates(
+                mGoogleApiClient,
+                this
+        ).setResultCallback(new ResultCallback<Status>() {
+            @Override
+            public void onResult(@NonNull Status status) {
+                mRequestingLocationUpdates = false;
+                // setButtonsEnabledState();
+            }
+        });
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        Log.d(TAG, "on startttttt");
+        mGoogleApiClient.connect();
+//        PreferenceManager.getDefaultSharedPreferences(this)
+//                .registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Within {@code onPause()}, we pause location updates, but leave the
+        // connection to GoogleApiClient intact.  Here, we resume receiving
+        // location updates if the user has requested them.
+        if (mGoogleApiClient.isConnected() && mRequestingLocationUpdates) {
+            startLocationUpdates();
+        }
+        // updateUI();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        // Stop location updates to save battery, but don't disconnect the GoogleApiClient object.
+        Log.d(TAG, "ON PAUSE");
+        if (mGoogleApiClient.isConnected()) {
+            Log.d(TAG, "DISCONNECT!!");
+            stopLocationUpdates();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+//        PreferenceManager.getDefaultSharedPreferences(this)
+//                .unregisterOnSharedPreferenceChangeListener(this);
+        super.onStop();
+        Log.d(TAG,"DISCONNECT");
+        mGoogleApiClient.disconnect();
+    }
+
+    /**
+     * Runs when a GoogleApiClient object successfully connects.
+     */
+    @Override
+    public void onConnected(Bundle connectionHint) {
+        // If the initial location was never previously requested, we use
+        // FusedLocationApi.getLastLocation() to get it. If it was previously requested, we store
+        // its value in the Bundle and check for it in onCreate(). We
+        // do not request it again unless the user specifically requests location updates by pressing
+        // the Start Updates button.
+        //
+        // Because we cache the value of the initial location in the Bundle, it means that if the
+        // user launches the activity,
+        // moves to a new location, and then changes the device orientation, the original location
+        // is displayed as the activity is re-created.
+        if (mCurrentLocation == null) {
+            mCurrentLocation = LocationServices.FusedLocationApi.getLastLocation(mGoogleApiClient);
+            mLastUpdateTime = DateFormat.getTimeInstance().format(new Date());
+            // updateLocationUI();
+        }
+        if (mRequestingLocationUpdates) {
+            Log.i(TAG, "in onConnected(), starting location updates");
+            startLocationUpdates();
+        }
+    }
+
+    private PendingIntent getPendingIntent() {
+        // Note: for apps targeting API level 25 ("Nougat") or lower, either
+        // PendingIntent.getService() or PendingIntent.getBroadcast() may be used when requesting
+        // location updates. For apps targeting API level O, only
+        // PendingIntent.getBroadcast() should be used. This is due to the limits placed on services
+        // started in the background in "O".
+
+        Intent intent = new Intent(this, LocationUpdatesIntentService.class);
+        intent.setAction(LocationUpdatesIntentService.ACTION_PROCESS_UPDATES);
+        return PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+//        Intent intent = new Intent(this, LocationUpdatesBroadcastReceiver.class);
+//        intent.setAction(LocationUpdatesBroadcastReceiver.ACTION_PROCESS_UPDATES);
+//        return PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+
+//    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
+//        if (s.equals(Utils.KEY_LOCATION_UPDATES_RESULT)) {
+//            // mLocationUpdatesResultView.setText(Utils.getLocationUpdatesResult(this));
+//        } else if (s.equals(Utils.KEY_LOCATION_UPDATES_REQUESTED)) {
+//            // updateButtonsState(Utils.getRequestingLocationUpdates(this));
+//        }
+//    }
+
+    /**
+     * Handles the Request Updates button and requests start of location updates.
+     */
+    public void requestLocationUpdates() {
+        try {
+            Log.i(TAG, "Starting location updates");
+            Utils.setRequestingLocationUpdates(this, true);
+            LocationServices.FusedLocationApi.requestLocationUpdates(
+                    mGoogleApiClient, mLocationRequest, getPendingIntent());
+        } catch (SecurityException e) {
+            Utils.setRequestingLocationUpdates(this, false);
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Callback that fires when the location changes.
+     */
+    @Override
+    public void onLocationChanged(Location location) {
+        mCurrentLocation = location;
+        mLastUpdateTime = DateFormat.getTimeInstance().format(new Date());
+        // updateLocationUI();
+        Toast.makeText(
+                MainActivity.this,
+                Double.toString(location.getLatitude()) + " " +
+                Double.toString(location.getLongitude()),
+                Toast.LENGTH_LONG).show();
+
+        Log.d(TAG, "위치 변경중!");
+    }
+
+    @Override
+    public void onConnectionSuspended(int cause) {
+        final String text = "Connection suspended";
+        Log.w(TAG, text + ": Error code: " + cause);
+        Toast.makeText(MainActivity.this, "Connection suspended", Toast.LENGTH_LONG).show();
+    }
+
+    @Override
+    public void onConnectionFailed(@NonNull ConnectionResult result) {
+        // Refer to the javadoc for ConnectionResult to see what error codes might be returned in
+        // onConnectionFailed.
+        Log.i(TAG, "Connection failed: ConnectionResult.getErrorCode() = " + result.getErrorCode());
+        Toast.makeText(MainActivity.this, "Connection failed", Toast.LENGTH_LONG).show();
+    }
+
+    /**
+     * Stores activity data in the Bundle.
+     */
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putBoolean(KEY_REQUESTING_LOCATION_UPDATES, mRequestingLocationUpdates);
+        savedInstanceState.putParcelable(KEY_LOCATION, mCurrentLocation);
+        savedInstanceState.putString(KEY_LAST_UPDATED_TIME_STRING, mLastUpdateTime);
+        super.onSaveInstanceState(savedInstanceState);
     }
 }


### PR DESCRIPTION
https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderApi
In Google APIs for Android document, it is mentioned that, regarding using FusedLocationProviderApi for location update request, it is recommend to use ```PendingIntent``` version of it for background/terminated and ```LocationListener``` version for foreground.

Therefore, I have implemented both of them to achieve best performance in terms of battery use.

When the app starts up, from ```onConnected```, pendingIntent receiver is removed while LocationListener updates location info while app in foreground. Then, when app goes in background/terminated, ```onPause``` is invoked and pendingIntent receiver goes alive for location update while in background/terminated.