### PR TITLE
Android: UNDO building from source

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     // From node_modules
 
-    compile project(':ReactAndroid')
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.google.android.gms:play-services-maps:10.0.1'
     compile 'com.google.android.gms:play-services-location:10.0.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,5 +18,9 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$rootDir/../node_modules/react-native/android"
+        }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,4 +17,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.useDeprecatedNdk=true
+android.useDeprecatedNdk=no

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -4,7 +4,9 @@ include ':app'
 include ':react-native-linear-gradient'
 project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
 
-include ':ReactAndroid'
-
-project(':ReactAndroid').projectDir = new File(
-        rootProject.projectDir, '../node_modules/react-native/ReactAndroid')
+// todo: uncomment the following if building from source needed
+//
+//include ':ReactAndroid'
+//
+//project(':ReactAndroid').projectDir = new File(
+//        rootProject.projectDir, '../node_modules/react-native/ReactAndroid')


### PR DESCRIPTION
Reverted building from source: https://github.com/Vinylize/Yetta-App/commit/760671541ced0ee41be297baae188e296a080aaa

Now NDK r10e no longer required. However, you may need building from source again in the future should you have any problems requiring latest bug fixes.

Also, it fixed build failure: https://github.com/Vinylize/Yetta-App/issues/76